### PR TITLE
Fixes selector for id_element

### DIFF
--- a/lib/generators/templates/autocomplete-rails.js
+++ b/lib/generators/templates/autocomplete-rails.js
@@ -21,7 +21,7 @@ $(document).ready(function(){
       select: function(event, ui) {
         $(this).val(ui.item.value);
         if ($(this).attr('id_element')) {
-          $($(this).attr('id_element')).val(ui.item.id);
+          $('#'+$(this).attr('id_element')).val(ui.item.id);
         }
         return false;
       }


### PR DESCRIPTION
This is a fix for issue #17 - https://github.com/crowdint/rails3-jquery-autocomplete/issues/#issue/17

Really simple, shouldn't be a problem to pull it in.  There were no Javascript tests that I could see, or I would have tried to write a test for it.
