### PR TITLE
Multiple with delimiter

### DIFF
--- a/lib/generators/templates/autocomplete-rails.js
+++ b/lib/generators/templates/autocomplete-rails.js
@@ -22,8 +22,10 @@ $(document).ready(function(){
 {
 	var self = null;
 	jQuery.fn.railsAutocomplete = function() {
-		return this.each(function() {
-			new jQuery.railsAutocomplete(this);
+		return this.live('focus',function() {
+			if (!this.railsAutoCompleter) {
+				this.railsAutoCompleter = new jQuery.railsAutocomplete(this);
+			}
 		});
 	};
 	


### PR DESCRIPTION
This batch of commits refactors the JS into a real jquery plugin, plus adds the ability to autocomplete multiple comma (or whatever) delimited values using example code from http://jqueryui.com/demos/autocomplete/#multiple-remote for something like a tag list.  Setting the 'data-delimiter' attribute on the input is what triggers that behavior.  The JS updates should be completely transparent to anyone currently using the gem.
