### PR TITLE
Autocomplete widget options

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -156,6 +156,59 @@ If you need to use the id of the selected object, you can use the *:id_element* 
 
 This will update the field with id *#some_element with the id of the selected object. The value for this option can be any jQuery selector.
 
+### Autocomplete widget options
+
+The Jquery autocomplete widget allow the following options: 'disabled', 'appendTo', 'delay', 'minLength' and 'source' (see: http://docs.jquery.com/UI/Autocomplete#option-disabled)
+
+You can define values for these options by adding HTML tags to your 'autocomplete_field' field in the view:
+
+#### disabled
+
+Disables (true) or enables (false) the autocomplete. Can be set when initialising (first creating) the autocomplete.
+
+Default = false
+
+    f.autocomplete_field :brand_name, autocomplete_brand_name_products_path, :autocomplete_disabled => true
+    
+If you disable de autocomplete when initialising, you'll probably want to enable it somewhere else in your javascript code:
+
+Get or set the disabled option, after init:
+
+    //getter
+    var disabled = $( ".selector" ).autocomplete( "option", "disabled" );
+    //setter
+    $( ".selector" ).autocomplete( "option", "disabled", false );
+
+#### appendTo
+
+Which element the menu should be appended to.
+
+Default: 'body'
+
+    f.autocomplete_field :brand_name, autocomplete_brand_name_products_path, :append_to => '#another_ellement'
+
+#### delay
+
+The delay in milliseconds the Autocomplete waits after a keystroke to activate itself. A zero-delay makes sense for local data (more responsive), but can produce a lot of load for remote data, while being less responsive.
+
+Default = 300
+
+    f.autocomplete_field :brand_name, autocomplete_brand_name_products_path, :delay => 100
+
+#### minLength
+
+The minimum number of characters a user has to type before the Autocomplete activates. Zero is useful for local data with just a few items. Should be increased when there are a lot of items, where a single character would match a few thousand items.
+
+Default = 2
+
+    f.autocomplete_field :brand_name, autocomplete_brand_name_products_path, :min_length => 0
+
+#### source
+
+Defines the data to use.
+
+The source options can obviously not be specified here since it is handled by this plugin itself.
+
 ## Formtastic
 
 If you are using [Formtastic](http://github.com/justinfrench/formtastic), you automatically get the *autocompleted_input* helper on *semantic_form_for*:

--- a/lib/generators/templates/autocomplete-rails.js
+++ b/lib/generators/templates/autocomplete-rails.js
@@ -1,6 +1,9 @@
 /*
 * Unobtrusive autocomplete
 *
+/*
+* Unobtrusive autocomplete
+*
 * To use it, you just have to include the HTML attribute autocomplete
 * with the autocomplete URL as the value
 *
@@ -48,7 +51,7 @@ $(document).ready(function(){
 			function extractLast( term ) {
 				return split( term ).pop().replace(/^\s+/,"");
 			}
-		
+            var append_to_ellement = $(e).attr('append_to');
 	    $(e).autocomplete({
 				source: function( request, response ) {
 					$.getJSON( $(e).attr('data-autocomplete'), {
@@ -58,9 +61,16 @@ $(document).ready(function(){
 				search: function() {
 					// custom minLength
 					var term = extractLast( this.value );
-					if ( term.length < 2 ) {
-						return false;
+                                        var min_length = $(e).attr('min_length') || 2;
+					if ( term.length < min_length ) {
+                                            return false;
 					}
+                                },
+				open: function() {
+                                        // when appending the result list to another ellement, we need to cancel the "position: relative;" css.
+                                        if (append_to_ellement){
+                                          $(append_to_ellement + ' ul.ui-autocomplete').css('position', 'static');
+                                        }
 				},
 				focus: function() {
 								// prevent value inserted on focus
@@ -84,7 +94,10 @@ $(document).ready(function(){
 					};
 				
 					return false;
-				}
+				},
+                                delay: ($(e).attr('delay') || 300),
+                                appendTo: append_to_ellement || "body",
+                                disabled: $(e).attr('autocomplete_disabled') || false
 			});
     }
   });


### PR DESCRIPTION
The Jquery autocomplete widget allow the following options: 'disabled', 'appendTo', 'delay', 'minLength' and 'source' (see: http://docs.jquery.com/UI/Autocomplete#option-disabled)

You can define values for these options by adding HTML tags to your 'autocomplete_field' field in the view:
#### disabled

Disables (true) or enables (false) the autocomplete. Can be set when initialising (first creating) the autocomplete.

Default = false

```
f.autocomplete_field :brand_name, autocomplete_brand_name_products_path, :autocomplete_disabled => true
```

If you disable de autocomplete when initialising, you'll probably want to enable it somewhere else in your javascript code:

Get or set the disabled option, after init:

```
//getter
var disabled = $( ".selector" ).autocomplete( "option", "disabled" );
//setter
$( ".selector" ).autocomplete( "option", "disabled", false );
```
#### appendTo

Which element the menu should be appended to.

Default: 'body'

```
f.autocomplete_field :brand_name, autocomplete_brand_name_products_path, :append_to => '#another_ellement'
```
#### delay

The delay in milliseconds the Autocomplete waits after a keystroke to activate itself. A zero-delay makes sense for local data (more responsive), but can produce a lot of load for remote data, while being less responsive.

Default = 300

```
f.autocomplete_field :brand_name, autocomplete_brand_name_products_path, :delay => 100
```
#### minLength

The minimum number of characters a user has to type before the Autocomplete activates. Zero is useful for local data with just a few items. Should be increased when there are a lot of items, where a single character would match a few thousand items.

Default = 2

```
f.autocomplete_field :brand_name, autocomplete_brand_name_products_path, :min_length => 0
```
#### source

Defines the data to use.

The source option can obviously not be specified here since it is handled by this plugin itself.
