### PR TITLE
Added MongoMapper Support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@
 
 An easy way to use jQuery's autocomplete with Rails 3.
 
-Supports both ActiveRecord and [mongoid](http://github.com/mongoid/mongoid).
+Supports both ActiveRecord, [mongoid](http://github.com/mongoid/mongoid), and [MongoMapper](https://github.com/jnunemaker/mongomapper).
 
 Works with [Formtastic](http://github.com/justinfrench/formtastic)
 and [SimpleForm](https://github.com/plataformatec/simple_form)
@@ -16,6 +16,10 @@ on how to use this gem with ActiveRecord [here](http://github.com/crowdint/rails
 
 You can find a [detailed example](http://github.com/crowdint/rails3-jquery-autocomplete-app/tree/mongoid)
 on how to use this gem with MongoID [here](http://github.com/crowdint/rails3-jquery-autocomplete-app/tree/mongoid). (Same thing, different branch)
+
+## MongoMapper
+
+TODO
 
 ## Before you start
 

--- a/rails3-jquery-autocomplete.gemspec
+++ b/rails3-jquery-autocomplete.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('sqlite3-ruby')
   s.add_development_dependency('mongoid', '>= 2.0.0')
+  s.add_development_dependency('mongo_mapper', '>= 0.9')
   s.add_development_dependency('bson_ext', '~>1.3.0')
   s.add_development_dependency('shoulda', '~>2.11.1')
 

--- a/test/implementations_test.rb
+++ b/test/implementations_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 require 'test_controller'
 require 'support/mongoid'
+require 'support/mongo_mapper'
 require 'support/active_record'
 
 class ActiveRecordControllerTest < ActionController::TestCase
@@ -31,5 +32,10 @@ end
 
 class MonogidControllerTest < ActionController::TestCase
   include Rails3JQueryAutocomplete::TestCase::Mongoid
+  include Rails3JQueryAutocomplete::TestCase
+end
+
+class MongoMapperControllerTest < ActionController::TestCase
+  include Rails3JQueryAutocomplete::TestCase::MongoMapper
   include Rails3JQueryAutocomplete::TestCase
 end

--- a/test/support/mongo_mapper.rb
+++ b/test/support/mongo_mapper.rb
@@ -1,0 +1,39 @@
+module Rails3JQueryAutocomplete
+  module TestCase
+    module MongoMapper
+      def setup
+        ::MongoMapper.connection = Mongo::Connection.new('localhost', 27017)
+        ::MongoMapper.database = "rails3_jquery_autocomplete_test"
+        
+        create_models
+
+        @controller = ActorsController.new
+        @movie1 = @movie_class.create(:name => 'Alpha')
+        @movie2 = @movie_class.create(:name => 'Alspha')
+        @movie3 = @movie_class.create(:name => 'Alzpha')
+      end
+
+      def teardown
+        destroy_models
+        ::MongoMapper.database.collections.select {|c| c.name !~ /system/ }.each(&:drop)
+      end
+
+      private
+      def create_models
+        @movie_class = Object.const_set(:Movie, Class.new)
+        @movie_class.send(:include, ::MongoMapper::Document)
+        @movie_class.key(:name, :class => String)
+        @movie_class.class_eval do
+          def display_name
+            "Movie: #{name}"
+          end
+        end
+      end
+
+      def destroy_models
+        Object.send(:remove_const, :Movie)
+      end
+
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,7 @@ ENV["RAILS_ENV"] = "test"
 
 require 'rails/all'
 require 'mongoid'
+require 'mongo_mapper'
 require 'shoulda'
 require 'rails/test_help'
 require 'rails3-jquery-autocomplete'


### PR DESCRIPTION
Hey,

I added MongoMapper support. MongoMapper >0.9 is ActiveModel compliant. Added tests to make sure it passes the established functionality of the gem. Would love to see this get merged in and pushed to the gem.

Thanks in advance.

Haris
