### PR TITLE
Clear old id from id_element if a change is made to the field

### DIFF
--- a/lib/generators/templates/autocomplete-rails.js
+++ b/lib/generators/templates/autocomplete-rails.js
@@ -96,6 +96,11 @@ $(document).ready(function(){
                             }
                         }
 					}
+// If a user changes the field after already making a selection make sure to remove id of a previous selection.
+                                        $(this).bind('change.clearId', function(){
+                                                $($(this).attr('id_element')).val("");
+                                                $(this).unbind('change.clearId');
+                                            });
 					$(this).trigger('railsAutocomplete.select');
 
 					return false;


### PR DESCRIPTION
This fixes the following:
Imagine that user selects a suggestion and id_element is populated with the id of the chosen element. Then the user decides to make a change. Unless user selects a new suggestion the id_element will still reflect the first suggestion. But the user may make a change to a new value that's not in the selection list. So this makes sure to clear the value of id_element if the user makes a change after making a selection.
