### PR TITLE
If a user changes the field after already making a selection make sure to remove id of a previous selection.

### DIFF
--- a/lib/generators/templates/autocomplete-rails.js
+++ b/lib/generators/templates/autocomplete-rails.js
@@ -97,9 +97,12 @@ $(document).ready(function(){
                         }
 					}
 // If a user changes the field after already making a selection make sure to remove id of a previous selection.
-                                        $(this).bind('change.clearId', function(){
-                                                $($(this).attr('id_element')).val("");
-                                                $(this).unbind('change.clearId');
+                                        var remember_string = this.value;
+                                        $(this).bind('keyup.clearId', function(){
+                                                if($(this).val().trim() != remember_string.trim()){
+                                                    $($(this).attr('id_element')).val("");
+                                                    $(this).unbind('keyup.clearId');
+                                                }
                                             });
 					$(this).trigger('railsAutocomplete.select');
 


### PR DESCRIPTION
Hold the previous value in var remember_string. If the user makes any changes besides adding a space at beginning or end then make sure to clear the object id from "#id_element".

This fixes the following:
Imagine that user selects a suggestion and id_element is populated with the id of the chosen element. Then the user decides to make a change. Unless user selects a new suggestion the id_element will still reflect the first suggestion. But the user may make a change to a new value that's not in the selection list. So this makes sure to clear the value of id_element if the user makes a change after making a selection.
