### PR TITLE
Fix route helper name in the README simple_form example.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -221,7 +221,7 @@ option.
 
     simple_form_for @product do |form|
       form.input :name
-      form.input :brand_name, :url => autocomplete_brand_name_path, :as => :autocomplete
+      form.input :brand_name, :url => autocomplete_brand_name_products_path, :as => :autocomplete
 
 # Cucumber
 


### PR DESCRIPTION
Fix route helper name in the README simple_form example.
