### PR TITLE
Fix HTML Validation Error

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -139,7 +139,7 @@ This options receives a method name as the parameter, and that method will be ca
 
 In the example above, you will search by _name_, but the autocomplete list will display the result of _funky_method_
 
-This wouldn't really make much sense unless you use it with the :id_element HTML tag. (See below)
+This wouldn't really make much sense unless you use it with the "data-id-element" attribute. (See below)
 
 Only the object's id and the column you are searching on will be returned in JSON, so if your display_value method requires another parameter, make sure to fetch it with the :extra_data option
 
@@ -176,9 +176,9 @@ Now your autocomplete code is unobtrusive, Rails 3 style.
 
 ### Getting the object id
 
-If you need to use the id of the selected object, you can use the *:id_element* HTML tag too:
+If you need to use the id of the selected object, you can use the *data-id-element* attribute too:
 
-    f.autocomplete_field :brand_name, autocomplete_brand_name_products_path, :id_element => '#some_element'
+    f.autocomplete_field :brand_name, autocomplete_brand_name_products_path, "data-id-element" => '#some_element'
 
 This will update the field with id *#some_element with the id of the selected object. The value for this option can be any jQuery selector.
 
@@ -188,7 +188,7 @@ If you need to extra data about the selected object, you can use the *:update_el
 
 The :update_elements attribute accepts a hash where the keys represent the object attribute/column data to use to update and the values are jQuery selectors to retrieve the HTML element to update:
 
-    f.autocomplete_field :brand_name, autocomplete_brand_name_products_path, :update_elements => {:id => '#id_element', :slogan => '#some_other_element'}
+    f.autocomplete_field :brand_name, autocomplete_brand_name_products_path, :update_elements => {:id => '#data-id-element', :slogan => '#some_other_element'}
 
     class ProductsController < Admin::BaseController
       autocomplete :brand, :name, :extra_data => [:slogan]

--- a/integration/app/views/id_elements/new.html.haml
+++ b/integration/app/views/id_elements/new.html.haml
@@ -6,7 +6,7 @@
     = form.text_field :name
   %p
     = form.label :brand_name
-    = form.autocomplete_field :brand_name, autocomplete_brand_name_id_elements_path, :id_element => '#product_brand_id'
+    = form.autocomplete_field :brand_name, autocomplete_brand_name_id_elements_path, 'data-id-element' => '#product_brand_id'
   %p
     = form.label :brand_id
     = form.text_field :brand_id

--- a/integration/public/javascripts/autocomplete-rails.js
+++ b/integration/public/javascripts/autocomplete-rails.js
@@ -11,7 +11,7 @@
 * be updated with the element id whenever you find a matching value
 *
 *   Example:
-*       <input type="text" data-autocomplete="/url/to/autocomplete" id_element="#id_field">
+*       <input type="text" data-autocomplete="/url/to/autocomplete" data-id-element="#id_field">
 */
 
 $(document).ready(function(){
@@ -85,8 +85,8 @@ $(document).ready(function(){
             this.value = terms.join( e.delimiter );
           } else {
             this.value = terms.join("");
-            if ($(this).attr('id_element')) {
-              $($(this).attr('id_element')).val(ui.item.id);
+            if ($(this).attr('data-id-element')) {
+              $($(this).attr('data-id-element')).val(ui.item.id);
             }
             if ($(this).attr('data-update-elements')) {
               var data = $(this).data(ui.item.id.toString());
@@ -99,7 +99,7 @@ $(document).ready(function(){
           var remember_string = this.value;
           $(this).bind('keyup.clearId', function(){
             if($(this).val().trim() != remember_string.trim()){
-              $($(this).attr('id_element')).val("");
+              $($(this).attr('data-id-element')).val("");
               $(this).unbind('keyup.clearId');
             }
           });

--- a/lib/generators/templates/autocomplete-rails.js
+++ b/lib/generators/templates/autocomplete-rails.js
@@ -11,7 +11,7 @@
 * be updated with the element id whenever you find a matching value
 *
 *   Example:
-*       <input type="text" data-autocomplete="/url/to/autocomplete" id_element="#id_field">
+*       <input type="text" data-autocomplete="/url/to/autocomplete" data-id-element="#id_field">
 */
 
 $(document).ready(function(){
@@ -85,8 +85,8 @@ $(document).ready(function(){
             this.value = terms.join( e.delimiter );
           } else {
             this.value = terms.join("");
-            if ($(this).attr('id_element')) {
-              $($(this).attr('id_element')).val(ui.item.id);
+            if ($(this).attr('data-id-element')) {
+              $($(this).attr('data-id-element')).val(ui.item.id);
             }
             if ($(this).attr('data-update-elements')) {
               var data = $(this).data(ui.item.id.toString());
@@ -99,7 +99,7 @@ $(document).ready(function(){
           var remember_string = this.value;
           $(this).bind('keyup.clearId', function(){
             if($(this).val().trim() != remember_string.trim()){
-              $($(this).attr('id_element')).val("");
+              $($(this).attr('data-id-element')).val("");
               $(this).unbind('keyup.clearId');
             }
           });


### PR DESCRIPTION
`id_element` is not a valid HTML tag attribute name, so we replace it with `data-id-element` which is valid in HTML 5.
