### PR TITLE
fix for issue #69, :id_element attribute not working

### DIFF
--- a/lib/rails3-jquery-autocomplete/form_helper.rb
+++ b/lib/rails3-jquery-autocomplete/form_helper.rb
@@ -34,6 +34,7 @@ module ActionView
     private
     def rewrite_autocomplete_option(options)
       options["data-update-elements"] = JSON.generate(options.delete :update_elements) if options[:update_elements]
+      options["data-id-element"] = options.delete :id_element if options[:id_element]
       options
     end
   end


### PR DESCRIPTION
Hi,

I have incorporated @andreteves [fix for above issue](https://github.com/andreteves/rails3-jquery-autocomplete/commit/2f602b2afb8720eb8808d5b1f74d048cc0d0ca29), so credit goes all to him.

The `:id_element` attribute is now rendered as HTML5 compliant `data-id-element` attribute.

Thanks in advance
