### PR TITLE
Improve mongoid regex query

### DIFF
--- a/lib/rails3-jquery-autocomplete/orm/mongoid.rb
+++ b/lib/rails3-jquery-autocomplete/orm/mongoid.rb
@@ -22,7 +22,11 @@ module Rails3JQueryAutocomplete
         limit          = get_autocomplete_limit(options)
         order          = get_autocomplete_order(method, options)
 
-        search = (is_full_search ? '.*' : '^') + term + '.*'
+        if is_full_search
+          search = '.*' + term + '.*'
+        else
+          search = '^' + term
+        end
         items  = model.where(method.to_sym => /#{search}/i).limit(limit).order_by(order)
       end
     end

--- a/test/lib/rails3-jquery-autocomplete/orm/mongoid_test.rb
+++ b/test/lib/rails3-jquery-autocomplete/orm/mongoid_test.rb
@@ -37,7 +37,7 @@ module Rails3JQueryAutocomplete
 
 				context 'not a full search' do
 					should 'do stuff' do
-						mock(@model).where({:field=>/^query.*/i}).mock!.limit(10).
+						mock(@model).where({:field=>/^query/i}).mock!.limit(10).
 								mock!.order_by([[:order, :asc]])
 
 						get_autocomplete_items(@parameters)	


### PR DESCRIPTION
I've removed the .\* for non-full-search.

From http://www.mongodb.org/display/DOCS/Advanced+Queries,

While /^a/, /^a._/, and /^a._$/ are equivalent, they will have different performance characteristics. They will all use an index in the same way, but the latter two will be slower as they have to scan the whole string. The first format can stop scanning after the prefix is matched.
