### PR TITLE
Added a :term_filter option to allow for input term transformation before lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,19 @@ This wouldn't really make much sense unless you use it with the "id_element" att
 
 Only the object's id and the column you are searching on will be returned in JSON, so if your display_value method requires another parameter, make sure to fetch it with the :extra_data option
 
+#### :term_filter
+
+If you want to transform incoming data before it's used to search, you can use the :display_value option.
+
+This option takes a message name as a parameter, and uses that method each invocation to transform the input term.
+
+    class ProductsController < Admin::BaseController
+      def transform_like_its_1984(term)
+        "#tubular {term}
+      end
+
+      autocomplete :brand, :name, :term_filter => :transform_like_its_1984
+	end
 
 #### :scopes
   Added option to use scopes. Pass scopes in an array.

--- a/lib/rails3-jquery-autocomplete/autocomplete.rb
+++ b/lib/rails3-jquery-autocomplete/autocomplete.rb
@@ -46,7 +46,7 @@ module Rails3JQueryAutocomplete
 
           method = options[:column_name] if options.has_key?(:column_name)
 
-          term = params[:term]
+          term = filter_term(params[:term], options[:term_filter])
 
           if term && !term.blank?
             #allow specifying fully qualified class name for model object
@@ -90,6 +90,14 @@ module Rails3JQueryAutocomplete
         # TODO: Come back to remove this if clause when test suite is better
         hash
       end
+    end
+
+    #
+    # Filters the input term against a specified method.
+    #
+    # Calls filter_method on self with term and returns the result.
+    def filter_term(term, filter_method)
+      returned_term = filter_method.nil? ? term : self.send(filter_method, term)
     end
   end
 end

--- a/test/lib/rails3-jquery-autocomplete/autocomplete_test.rb
+++ b/test/lib/rails3-jquery-autocomplete/autocomplete_test.rb
@@ -55,5 +55,19 @@ module Rails3JQueryAutocomplete
         end
       end
     end
+
+    context '#filter_term' do
+      should 'return the term if :term_filter_method is blank' do
+        term = "test_term"
+        assert_equal term, filter_term(term, nil)
+      end
+
+      should 'apply the passed method to term' do
+        test_term = "test_term"
+        returned_term = "returned_term"
+        mock(self).send(:test_method, test_term) {returned_term}
+        assert_equal returned_term, filter_term(test_term, :test_method)
+      end
+    end
   end
 end

--- a/test/lib/rails3-jquery-autocomplete_test.rb
+++ b/test/lib/rails3-jquery-autocomplete_test.rb
@@ -4,6 +4,8 @@ module Rails3JQueryAutocomplete
   class Rails3JQueryAutocompleteTest < ActionController::TestCase
     ActorsController = Class.new(ActionController::Base)
     ActorsController.autocomplete(:movie, :name)
+	DirectorsController = Class.new(ActionController::Base)
+	DirectorsController.autocomplete(:movie, :name, :term_filter => :test_term, :display_value => :name)
 
     class ::Movie ; end
 
@@ -31,6 +33,25 @@ module Rails3JQueryAutocomplete
         should "render an empty hash" do
           mock(@controller).json_for_autocomplete({}, :name, nil)
           get :autocomplete_movie_name
+        end
+      end
+    end
+
+    context '#autocomplete_object_method_filtered' do
+      setup do
+		@controller = DirectorsController.new
+		@items = {}
+		@options = { 	:display_value => :name, :term_filter => :test_term }
+      end
+
+      context 'term_filter is set' do
+        should "render the JSON items" do
+          mock(@controller).test_term("query") {"querty"}
+          mock(@controller).get_autocomplete_items({
+            :model => Movie, :method => :name, :options => @options, :term => "querty"
+          }) { @items }
+          mock(@controller).json_for_autocomplete(@items, :name, nil)
+          get :autocomplete_movie_name, :term => 'query'
         end
       end
     end


### PR DESCRIPTION
``` ruby
ProductController < ActionController.base

  def make_mimsy (term)
    "#{term}IsMimsy"
  end

  :autocomplete :product, :name, :term_filter => :make_mimsy

end
```
