### PR TITLE
Scopes doesn't allow for lambda 

### DIFF
--- a/lib/rails3-jquery-autocomplete/orm/active_record.rb
+++ b/lib/rails3-jquery-autocomplete/orm/active_record.rb
@@ -24,7 +24,11 @@ module Rails3JQueryAutocomplete
           scopes.each do |scope|
             scope_method = scope.gsub(/\(.*\)/, "")
             scope_params = scope.scan(/\(([^}]+)\)/).flatten[0]
-            items = items.send(scope_method, scope_params)
+            items = if scope_params.blank?
+              items.send(scope_method)
+            else
+              items.send(scope_method, scope_params)
+            end
           end
         end
 


### PR DESCRIPTION
The :scopes option doesn't allow for a parameter to be passed to the scope, as **send** requires that the parameters be split from the method.  I've changed the way scopes are parsed for active record.
