### PR TITLE
jQuery 'noData' event for autocomplete.

### DIFF
--- a/lib/assets/javascripts/autocomplete-rails-uncompressed.js
+++ b/lib/assets/javascripts/autocomplete-rails-uncompressed.js
@@ -47,9 +47,13 @@
 
       jQuery(e).autocomplete({
         source: function( request, response ) {
+            var outerThis = this;
           jQuery.getJSON( jQuery(e).attr('data-autocomplete'), {
             term: extractLast( request.term )
           }, function() {
+              if (arguments[0].length == 0){
+                  jQuery(outerThis.element[0]).trigger('railsAutocomplete.noData');
+              }
             jQuery(arguments[0]).each(function(i, el) {
               var obj = {};
               obj[el.id] = el;


### PR DESCRIPTION
jQuery 'noData' event for autocomplete. Triggered when sql-query returns no results. It's useful to show messages, somethink like "sorry, do data found" etc. 
To bind a callback function jQuery("#autocomplete_id").bind("railsAutocomplete.noData", function(){ alert('no data:('); })

Guys, please review. I find it useful for myself, hope somebody else will find it useful too.
