### PR TITLE
Check whether the specific model uses the PostgreSQLAdapter, not if PGconn is defined.

### DIFF
--- a/lib/rails3-jquery-autocomplete/orm/active_record.rb
+++ b/lib/rails3-jquery-autocomplete/orm/active_record.rb
@@ -39,12 +39,13 @@ module Rails3JQueryAutocomplete
       def get_autocomplete_where_clause(model, term, method, options)
         table_name = model.table_name
         is_full_search = options[:full]
-        like_clause = (postgres? ? 'ILIKE' : 'LIKE')
+        like_clause = (postgres?(model) ? 'ILIKE' : 'LIKE')
         ["LOWER(#{table_name}.#{method}) #{like_clause} ?", "#{(is_full_search ? '%' : '')}#{term.downcase}%"]
       end
 
-      def postgres?
-        defined?(PGconn)
+      def postgres? model
+        # Figure out if this particular model uses the PostgreSQL adapter                                 
+        model.connection.class.to_s.match(/PostgreSQLAdapter/)
       end
     end
   end


### PR DESCRIPTION
This is the issue I mentioned in email last week, and my fix for it.  Something very much like this will do the trick, if not this exactly.  It fixes problems where multiple adapters are used in the same application, such as Issue #118.
