### PR TITLE
Restore possibility to give a block to autocomplete

### DIFF
--- a/lib/rails3-jquery-autocomplete/autocomplete.rb
+++ b/lib/rails3-jquery-autocomplete/autocomplete.rb
@@ -57,7 +57,11 @@ module Rails3JQueryAutocomplete
             items = {}
           end
 
-          render :json => json_for_autocomplete(items, options[:display_value] ||= method, options[:extra_data])
+          render :json => if block_given?
+                            yield items
+                          else
+                            json_for_autocomplete(items, options[:display_value] ||= method, options[:extra_data])
+                          end
         end
       end
     end


### PR DESCRIPTION
This isn't only useful to set a different json encoder. It adds the possibility of aggregating the items and returning a different set of autocomplete options.
