### PR TITLE
More complete test coverage and updating README

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,17 @@ integration folder:
     rake db:migrate
     cucumber
 
+## Where to test what
+
+If you're making or tweaking a plugin (such as the formastic plugin or
+simple\_form plugin), check out the simple\_form\_plugin\_test for an
+example of how to test it as part of the main `rake test` run.
+Historically, plugins like these had been tested (shoddily) as part of
+the integration tests. Feel free to remove them from the integration
+suite and move them into the main suite. Your tests will run much
+faster, and there will be less likelihood of your feature breaking in
+the future. Thanks!
+
 # Thanks to
 
 Everyone on [this list](https://github.com/crowdint/rails3-jquery-autocomplete/contributors)

--- a/integration/features/autocomplete.feature
+++ b/integration/features/autocomplete.feature
@@ -58,13 +58,6 @@ Feature: Autocomplete
     Then the "Feature Name" field should contain "Glowy,Shiny"
 
   @javascript
-  Scenario: Autocomplete with simple_form
-    Given I go to the new simple form page
-    And I fill in "Brand name" with "al"
-    And I choose "Alpha" in the autocomplete list
-    Then the "Brand name" field should contain "Alpha"
-
-  @javascript
   Scenario: Autocomplete with scope
     Given the "Kappa" brand has an address
     Given I go to the new scoped autocomplete page

--- a/lib/rails3-jquery-autocomplete/simple_form_plugin.rb
+++ b/lib/rails3-jquery-autocomplete/simple_form_plugin.rb
@@ -1,8 +1,13 @@
 module SimpleForm
+
   module Inputs
     class AutocompleteInput < Base
       def input
-        @builder.autocomplete_field(attribute_name, options[:url], input_html_options.merge(update_elements(options[:update_elements])))
+        @builder.autocomplete_field(
+          attribute_name,
+          options[:url],
+          html_options
+        )
       end
 
     protected
@@ -15,6 +20,10 @@ module SimpleForm
         placeholder_present?
       end
 
+      def html_options
+        input_html_options.merge update_elements options[:update_elements]
+      end
+
       def update_elements(elements)
         if elements
           {'data-update-elements' => elements.to_json}
@@ -24,10 +33,9 @@ module SimpleForm
       end
     end
   end
-end
 
-module SimpleForm
   class FormBuilder
     map_type :autocomplete, :to => SimpleForm::Inputs::AutocompleteInput
   end
+
 end

--- a/test/lib/rails3-jquery-autocomplete/simple_form_plugin_test.rb
+++ b/test/lib/rails3-jquery-autocomplete/simple_form_plugin_test.rb
@@ -14,9 +14,19 @@ module Rails3JQueryAutocomplete
       assert_select "input#user_name[data-autocomplete=/test]"
     end
 
+    should "add a data-update-elements attribute with encoded data if passed an :update_elements option" do
+      with_input_for @user, :name, :autocomplete, :update_elements => { :id => '#this', :ego => '#that' }
+      assert_select "input#user_name[data-update-elements='{&quot;id&quot;:&quot;#this&quot;,&quot;ego&quot;:&quot;#that&quot;}']"
+    end
+
     should "not add a data-update-elements attribute if not passed an :update_elements option" do
       with_input_for @user, :name, :autocomplete, :url => '/test'
       assert_no_select "input#user_name[data-update-elements]"
+    end
+
+    should "add arbitrary html options, if specified" do
+      with_input_for @user, :name, :autocomplete, :input_html => { :class => "superego" }
+      assert_select "input#user_name.superego"
     end
 
   end


### PR DESCRIPTION
I added a couple of other tests to the simple_form plugin. I wasn't sure what a couple of the methods in the file were there for, so they are still untested, but it's a lot better than it was. (`SimpleForm::Inputs::AutocompleteInput#limit` and `#has_placeholder?`&mdash;what are they there for? Feel free to add tests for them, if you know!)

I also added a "Where to test what" section to the README, explaining the new "best practice". Feel free to edit that in to the two sections above it, if you can. Or let me know if you'd like me to take a whack at making it more concise.
