### PR TITLE
Add option to send additional fields with the auto complete query.

### DIFF
--- a/lib/assets/javascripts/autocomplete-rails-uncompressed.js
+++ b/lib/assets/javascripts/autocomplete-rails-uncompressed.js
@@ -47,9 +47,14 @@
 
       jQuery(e).autocomplete({
         source: function( request, response ) {
-          jQuery.getJSON( jQuery(e).attr('data-autocomplete'), {
-            term: extractLast( request.term )
-          }, function() {
+            var queryFields = {term: extractLast( request.term )};
+            var fieldsAttr = jQuery(e).attr('data-autocomplete-fields');
+            if (fieldsAttr != null) {
+              var fields = JSON.parse(fieldsAttr);
+              for(var k in fields) queryFields[k] = jQuery(fields[k]).val();
+            }
+          jQuery.getJSON( jQuery(e).attr('data-autocomplete'), queryFields,
+          function() {
             jQuery(arguments[0]).each(function(i, el) {
               var obj = {};
               obj[el.id] = el;

--- a/lib/rails3-jquery-autocomplete/form_helper.rb
+++ b/lib/rails3-jquery-autocomplete/form_helper.rb
@@ -35,6 +35,7 @@ module ActionView
     def rewrite_autocomplete_option(options)
       options["data-update-elements"] = JSON.generate(options.delete :update_elements) if options[:update_elements]
       options["data-id-element"] = options.delete :id_element if options[:id_element]
+      options["data-autocomplete-fields"] = JSON.generate(options.delete :fields) if options[:fields]
       options
     end
   end


### PR DESCRIPTION
Hi!

In many cases you wish to send additional fields with the auto complete query.  An example can be that you first select a project, and then use auto complete for a work record description text field, and you wish to prioritize previous work records from the same project before those from other projects.

This pull request adds a "fields" option to the FormHelper.  The option is expected to contain a Ruby hash with names of query params as keys and CSS selectors for the referenced fields as values.

```
<%=form_for @work do |f| %>
  <%=f.autocomplete_field :description, '/works/auto_complete_work_description',
      :fields => {:project_id => '#work_project_id'}%>
<% end %>
```

The change should be backwards compatible and not affect any legacy code.  Please merge and include in the next gem release.
