### PR TITLE
Formtastic throws NoMethodError on autocompleted_input lately.

### DIFF
--- a/lib/rails3-jquery-autocomplete/formtastic.rb
+++ b/lib/rails3-jquery-autocomplete/formtastic.rb
@@ -14,6 +14,16 @@ begin
     #
 
     module Formtastic
+
+      class FormBuilder
+        def autocompleted_input(*args)
+          options = args.extract_options!
+          input(*args << options.reverse_merge(:as => :autocomplete))
+        end
+
+        alias_method :autocomplete_input, :autocompleted_input
+      end
+
       module Inputs
         class AutocompleteInput
           include Base


### PR DESCRIPTION
So, bringing it back.
