### PR TITLE
Include Autocomplete functionality and forms builders integration on correcponding on_load event

### DIFF
--- a/lib/rails3-jquery-autocomplete.rb
+++ b/lib/rails3-jquery-autocomplete.rb
@@ -10,14 +10,18 @@ module Rails3JQueryAutocomplete
   end
 end
 
-class ActionController::Base
-  include Rails3JQueryAutocomplete::Autocomplete
+ActiveSupport.on_load(:action_controller) do
+  class ActionController::Base
+    include Rails3JQueryAutocomplete::Autocomplete
+  end
 end
 
-require 'rails3-jquery-autocomplete/formtastic'
+ActiveSupport.on_load(:action_view) do
+  require 'rails3-jquery-autocomplete/formtastic'
 
-begin
-  require 'simple_form'
-  require 'rails3-jquery-autocomplete/simple_form_plugin'
-rescue LoadError
+  begin
+    require 'simple_form'
+    require 'rails3-jquery-autocomplete/simple_form_plugin'
+  rescue LoadError
+  end
 end


### PR DESCRIPTION
It might be a good idea to wrap the functionally loading with corresponding ActiveSupport.on_load events.

That should give a better way for including a side functionality into this gem for other gems. Say, some that are for internal projects.
