### PR TITLE
Add multiple field instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ If you are not using a FormBuilder (form_for) or you just want to include an aut
       autocomplete_field_tag 'address', '', address_autocomplete_path, :size => 75
     end
 
-#### Autocomplete with Multiple Values Separated by Delimiter
+#### Multiple Values Separated by Delimiter
 
 To generate an autocomplete input field that accepts multiple values separated by a given delimiter, add the `'data-delimiter'` and `:multiple` options:
 


### PR DESCRIPTION
I thought it could be helpful to have instructions on setting up an autocomplete field that accepts multiple values in the readme.  It took some searching this morning but I eventually found the solution in your issues, (issue #20 I believe).  I've added a few lines in the 'Views' section about adding the `'data-delimiter' => ','` and `:multiple => true` options.  I feel that this is a fairly common use case scenario (adding multiple tags to a model object, etc.) so deserves to be in the main documentation.  Great gem btw, very easy to drop in and get working quickly.  Thanks! 
