### PR TITLE
searching using active_record scope

### DIFF
--- a/lib/rails3-jquery-autocomplete/orm/active_record.rb
+++ b/lib/rails3-jquery-autocomplete/orm/active_record.rb
@@ -13,6 +13,7 @@ module Rails3JQueryAutocomplete
         term    = parameters[:term]
         method  = parameters[:method]
         options = parameters[:options]
+        search_scope = options[:search_scope]
         scopes  = Array(options[:scopes])
         where   = options[:where]
         limit   = get_autocomplete_limit(options)
@@ -24,8 +25,14 @@ module Rails3JQueryAutocomplete
         scopes.each { |scope| items = items.send(scope) } unless scopes.empty?
 
         items = items.select(get_autocomplete_select_clause(model, method, options)) unless options[:full_model]
-        items = items.where(get_autocomplete_where_clause(model, term, method, options)).
-            limit(limit).order(order)
+
+        if search_scope.blank?
+          items = items.where(get_autocomplete_where_clause(model, term, method, options))
+        else
+          items = items.send(search_scope, get_autocomplete_term_for_like(term, options))
+        end
+
+        items = items.limit(limit).order(order)
         items = items.where(where) unless where.blank?
 
         items
@@ -38,9 +45,13 @@ module Rails3JQueryAutocomplete
 
       def get_autocomplete_where_clause(model, term, method, options)
         table_name = model.table_name
-        is_full_search = options[:full]
         like_clause = (postgres?(model) ? 'ILIKE' : 'LIKE')
-        ["LOWER(#{table_name}.#{method}) #{like_clause} ?", "#{(is_full_search ? '%' : '')}#{term.downcase}%"]
+        ["LOWER(#{table_name}.#{method}) #{like_clause} ?", get_autocomplete_term_for_like(term, options)]
+      end
+
+      def get_autocomplete_term_for_like(term, options)
+        is_full_search = options[:full]
+        "#{(is_full_search ? '%' : '')}#{term.downcase}%"
       end
 
       def postgres?(model)

--- a/test/lib/rails3-jquery-autocomplete/orm/active_record_test.rb
+++ b/test/lib/rails3-jquery-autocomplete/orm/active_record_test.rb
@@ -81,6 +81,24 @@ module Rails3JQueryAutocomplete
         end
       end
 
+      context '#get_autocomplete_term_for_like' do
+        setup do
+          @term = 'query'
+          @options = {}
+        end
+
+          should 'return term with % added' do
+            assert_equal "query%", get_autocomplete_term_for_like(@term, @options)
+          end
+
+        context 'full search' do
+          should 'return term sourrounded by %%' do
+            @options[:full] = true
+            assert_equal "%query%", get_autocomplete_term_for_like(@term, @options)
+          end
+        end
+      end
+
       context '#get_autocomplete_where_clause' do
         setup do
           @model = Object.new


### PR DESCRIPTION
Added ability to use active record scope for search. It enables using complex queries (use OR, JOIN other tables etc.) in search.

Example usage:

In model just add `scope` with lamba and one parameter. In this example it is called `:autocomplete_by_names`:

``` ruby
class User < ActiveRecord::Base
  scope :autocomplete_by_names, lambda { |query|
    select("users.contact_name, users.business_name").where("(users.contact_name LIKE :query OR users.business_name LIKE :query)", :query => query)
  }

  def name_with_id
    "#{business_name.blank? ? contact_name : business_name} (#{id})"
  end
end
```

In controller in `autocomplete` call use just `:id` (if you don't want any other column to be selected from database or if you use select in your scope) and add new option `:search_scope` and specify the name of your `scope` `:autocomplete_by_names`:

``` ruby
class UsersController < ApplicationController
  autocomplete :user, :id, :full => true, :display_value => :name_with_id, :search_scope => :autocomplete_by_names
end
```

All other `autocomplete` options work with this.
