### PR TITLE
Prevent deprecation warning in Rails 4

### DIFF
--- a/lib/rails3-jquery-autocomplete/orm/active_record.rb
+++ b/lib/rails3-jquery-autocomplete/orm/active_record.rb
@@ -19,7 +19,7 @@ module Rails3JQueryAutocomplete
         order   = get_autocomplete_order(method, options, model)
 
 
-        items = ::Rails::VERSION::MAJOR >= 4 ? model.all : model.scoped
+        items = (::Rails::VERSION::MAJOR * 10 + ::Rails::VERSION::MINOR) >= 41 ? model.all : model.scoped
 
         scopes.each { |scope| items = items.send(scope) } unless scopes.empty?
 


### PR DESCRIPTION
When running master with Rails 4 we get this:

```
DEPRECATION WARNING: Model.scoped is deprecated. Please use Model.all instead.
```

This PR changes active_record.rb to use `Model.all` instead of the deprecated `Model.scoped` if possible
