### PR TITLE
Fix deprecation warning in Rails 4.x

### DIFF
--- a/lib/rails3-jquery-autocomplete/orm/active_record.rb
+++ b/lib/rails3-jquery-autocomplete/orm/active_record.rb
@@ -19,7 +19,7 @@ module Rails3JQueryAutocomplete
         order   = active_record_get_autocomplete_order(method, options, model)
 
 
-        items = model.where(nil)
+        items = (::Rails::VERSION::MAJOR * 10 + ::Rails::VERSION::MINOR) >= 40 ? model.where(nil) : model.scoped
 
         scopes.each { |scope| items = items.send(scope) } unless scopes.empty?
 


### PR DESCRIPTION
Following pull request #255, I suggest this change to make the fix backward-compatible with Rails 4.0 too.
`where(nil)` seems to be the correct substitute of `scoped`, without raising the deprecation warning.
All the tests are working fine under Rails 3.x and I tested on a production application with success.
