### PR TITLE
Change Autocomplete.autocomplete default of items in 1.0.13

### DIFF
--- a/lib/rails3-jquery-autocomplete/autocomplete.rb
+++ b/lib/rails3-jquery-autocomplete/autocomplete.rb
@@ -69,7 +69,7 @@ module Rails3JQueryAutocomplete
             items = get_autocomplete_items(:model => get_object(class_name), \
               :options => options, :term => term, :method => method)
           else
-            items = {}
+            items = []
           end
 
           render :json => json_for_autocomplete(items, options[:display_value] ||= method, options[:extra_data], &block)


### PR DESCRIPTION
in `Autocomplete.json_for_autocomplete`, collect! is being called on items, which is defaulted to `items = {}`, however `.collect!` is not a Hash method, which is causing errors. I suggest changing it to `items - []`. I haven't this, because the 1.0.13 code hasn't been posted.
