### PR TITLE
1.0.13 broken for Mongoid, items is not an array

### DIFF
--- a/lib/rails3-jquery-autocomplete/autocomplete.rb
+++ b/lib/rails3-jquery-autocomplete/autocomplete.rb
@@ -97,7 +97,7 @@ module Rails3JQueryAutocomplete
     # Hash also includes a key/value pair for each method in extra_data
     #
     def json_for_autocomplete(items, method, extra_data=[])
-      items.collect! do |item|
+      items = items.collect do |item|
         hash = {"id" => item.id.to_s, "label" => item.send(method), "value" => item.send(method)}
         extra_data.each do |datum|
           hash[datum] = item.send(datum)


### PR DESCRIPTION
The `items` that get passed in here is a Mongoid criteria.  So, doing a collect! on it does not update it and was causing the data to just be a to_json of the objects, breaking autocomplete.  This change is a lot more flexible for different types of objects getting passed in.
