### PR TITLE
Forcing root node false for rendering JSON

### DIFF
--- a/lib/rails3-jquery-autocomplete/autocomplete.rb
+++ b/lib/rails3-jquery-autocomplete/autocomplete.rb
@@ -72,7 +72,7 @@ module Rails3JQueryAutocomplete
             items = {}
           end
 
-          render :json => json_for_autocomplete(items, options[:display_value] ||= method, options[:extra_data], &block)
+          render :json => json_for_autocomplete(items, options[:display_value] ||= method, options[:extra_data], &block), root: false
         end
       end
     end


### PR DESCRIPTION
Per issue #260 - the JS assumes there is no root node (and breaks if there is one present). For many folks using Rails, they have root nodes turned on by default in the ActiveModel serializers (for instance if you have an API for your Rails app, this is a very common practice).

This default can be easily overridden without any risks I can see. This pull request does this.

I didn't see any specs around the `define_method("autocomplete_#{object}_#{method}")` section to the `autocomplete` class method so I didn't add any test for this. However, it doesn't break anything in the existing test suite.

I think this can only help users avoid an issue with root nodes and hope you'll merge it in :) But I'm open to feedback if you'd like me to change anything.
