### PR TITLE
Detect the ORM correctly for hierarchies.

### DIFF
--- a/lib/rails3-jquery-autocomplete/autocomplete.rb
+++ b/lib/rails3-jquery-autocomplete/autocomplete.rb
@@ -41,9 +41,9 @@ module Rails3JQueryAutocomplete
       def autocomplete(object, method, options = {}, &block)
 
         define_method("get_prefix") do |model|
-          if model.superclass == Object && model.include?(Mongoid::Document)
+          if model.include?(Mongoid::Document)
             'mongoid'
-          elsif model.superclass == Object && model.include?(MongoMapper::Document)
+          elsif model.include?(MongoMapper::Document)
             'mongo_mapper'
           else
             'active_record'


### PR DESCRIPTION
We have a hierarchy of classes as following:

``` ruby
class Shape
  include Mongoid::Document
end

class Triangle < Shape
end
```

Because `Triangle`'s direct ascendant isn't `Object`, the gem fails to detect the ORM correctly. I'm not sure what was the purpose of checking the superclass, so the PR may need some modification.
