### PR TITLE
Changed input to solve deprecation issue.

### DIFF
--- a/lib/rails3-jquery-autocomplete/simple_form_plugin.rb
+++ b/lib/rails3-jquery-autocomplete/simple_form_plugin.rb
@@ -17,11 +17,11 @@ module SimpleForm
     class AutocompleteInput < Base
       include Autocomplete
 
-      def input
+      def input(wrapper_options)
         @builder.autocomplete_field(
           attribute_name,
           options[:url],
-          rewrite_autocomplete_option
+          merge_wrapper_options(rewrite_autocomplete_option, wrapper_options)
         )
       end
 


### PR DESCRIPTION
See https://github.com/plataformatec/simple_form/pull/997 for an
explanation. Fixes issue #284 .
But at the same time it breaks the testing suite since this only works for newer simple form versions. The testing suite is using simple_form 1.5.2 at the time of writing.
